### PR TITLE
Language - Reordered the languages to alphabetical order

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,13 +265,13 @@
                         <span data-i18n="dgc-language">Language</span>
                       </a>
                       <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                          <li><a class="dropdown-item select-lang" data-lang="en">English</a></li>
-                          <li><a class="dropdown-item select-lang" data-lang="de">Deutsch</a></li>
+			  <li><a class="dropdown-item select-lang" data-lang="id">Bahasa Indonesia</a></li>
+			  <li><a class="dropdown-item select-lang" data-lang="de">Deutsch</a></li>
+                          <li><a class="dropdown-item select-lang" data-lang="en">English</a></li
                           <li><a class="dropdown-item select-lang" data-lang="es">Español</a></li>
                           <li><a class="dropdown-item select-lang" data-lang="fr">Français</a></li>
+			  <li><a class="dropdown-item select-lang" data-lang="hi">Hindi</a></li>
                           <li><a class="dropdown-item select-lang" data-lang="it">Italiano</a></li>
-                          <li><a class="dropdown-item select-lang" data-lang="hi">Hindi</a></li>
-                          <li><a class="dropdown-item select-lang" data-lang="id">Bahasa Indonesia</a></li>
                       </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Description
Reordered the current languages to alphabetical order. In the future, it might be a good idea for this to become a standard for the languages dropdown.

### Motivation and Context
Since it appears we'll be adding more languages long term to the main page, I think it makes sense that they be alphabetical in the dropdown.

### How Has This Been Tested?
Tested the dropdown to confirm existing languages work and appear correctly.

### Screenshots (if appropriate):

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] GitHub issue linked
- [ ] The necessary translations have been added for all languages
- [ ] Any documentation has been updated accordingly
- [x] Responsive sizes (Mobile) tested
- [ ] Cross Browser tested if necessary
- [x] Conflicts resolved
